### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A light weight & simple & easy camera for iOS by Swift. It uses `CoreMotion` fra
 
 ## Installation
 #### iOS 8 and newer
-DKCamera is available on Cocoapods. Simply add the following line to your podfile:
+DKCamera is available on CocoaPods. Simply add the following line to your podfile:
 
 ```ruby
 # For latest release in cocoapods


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
