### PR TITLE
Handle iPhone X notch by respecting safe area

### DIFF
--- a/DKCamera/DKCamera.swift
+++ b/DKCamera/DKCamera.swift
@@ -192,6 +192,21 @@ open class DKCamera: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
         self.motionManager.stopAccelerometerUpdates()
     }
     
+    /*
+         If setupUI() is called before the view has loaded,
+         it doesn't have safe area insets yet, so we need to
+         implement this function to do re-sizing if the safe area
+         insets change
+     */
+    open override func viewSafeAreaInsetsDidChange() {
+        if #available(iOS 11, *) {
+            // Handle iPhone X notch - resize bottom view to respect safe area
+            let safeAreaBottomInset = view.safeAreaInsets.bottom
+            bottomView.frame.origin = CGPoint(x: 0,
+                                              y: contentView.bounds.height - (bottomView.frame.size.height + safeAreaBottomInset))
+        }
+    }
+    
     override open func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
@@ -212,7 +227,15 @@ open class DKCamera: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
         
         let bottomViewHeight: CGFloat = 70
         bottomView.bounds.size = CGSize(width: contentView.bounds.width, height: bottomViewHeight)
-        bottomView.frame.origin = CGPoint(x: 0, y: contentView.bounds.height - bottomViewHeight)
+        
+        if #available(iOS 11, *) {
+            // Handle iPhone X notch - respect safe area
+            let safeAreaBottomInset = view.safeAreaInsets.bottom
+            bottomView.frame.origin = CGPoint(x: 0, y: contentView.bounds.height - (bottomViewHeight + safeAreaBottomInset))
+        } else {
+            bottomView.frame.origin = CGPoint(x: 0, y: contentView.bounds.height - bottomViewHeight)
+        }
+        
         bottomView.autoresizingMask = [.flexibleWidth, .flexibleTopMargin]
         bottomView.backgroundColor = UIColor(white: 0, alpha: 0.4)
         contentView.addSubview(bottomView)


### PR DESCRIPTION
Make sure that the bottom view is handling safe area insets properly so the UI doesn't overlap with the notch. Note that you can apply the same logic to the cancel button if desired, but since this view controller is presented full-screen and the status bar is hidden, there is no conflict with that button.

Without respecting safe area:
![simulator screen shot - iphone x - 2017-09-16 at 09 39 38](https://user-images.githubusercontent.com/9664844/30512939-20a5184e-9ac8-11e7-956e-d95a0b10aae4.png)

Respecting safe area:
![simulator screen shot - iphone x - 2017-09-16 at 10 10 10](https://user-images.githubusercontent.com/9664844/30512940-2371a22c-9ac8-11e7-8358-e032bd88bfd4.png)
