### PR TITLE
add showsCameraSwitchButton flag

### DIFF
--- a/DKCamera/DKCamera.swift
+++ b/DKCamera/DKCamera.swift
@@ -213,6 +213,13 @@ open class DKCamera: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
             self.contentView.isHidden = !self.showsCameraControls
         }
     }
+  
+    /// set to NO to hide all standard camera UI. default is YES.
+    open var showsCameraSwitchButton = true {
+      didSet {
+        self.cameraSwitchButton.isHidden = !self.showsCameraSwitchButton
+      }
+    }
     
     public let captureSession = AVCaptureSession()
     open var previewLayer: AVCaptureVideoPreviewLayer!

--- a/DKCamera/DKCamera.swift
+++ b/DKCamera/DKCamera.swift
@@ -206,19 +206,13 @@ open class DKCamera: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
     /// Determines whether or not the rotation is enabled.
     
     open var allowsRotate = false
+    open var showsCameraSwitchButton = false
     
     /// set to NO to hide all standard camera UI. default is YES.
     open var showsCameraControls = true {
         didSet {
             self.contentView.isHidden = !self.showsCameraControls
         }
-    }
-  
-    /// set to NO to hide all standard camera UI. default is YES.
-    open var showsCameraSwitchButton = true {
-      didSet {
-        self.cameraSwitchButton.isHidden = !self.showsCameraSwitchButton
-      }
     }
     
     public let captureSession = AVCaptureSession()
@@ -435,6 +429,7 @@ open class DKCamera: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
             cameraSwitchButton.addTarget(self, action: #selector(DKCamera.switchCamera), for: .touchUpInside)
             cameraSwitchButton.setImage(cameraResource.cameraSwitchImage(), for: .normal)
             cameraSwitchButton.sizeToFit()
+            cameraSwitchButton.isHidden = !self.showsCameraSwitchButton
             
             return cameraSwitchButton
         }()


### PR DESCRIPTION
Add optional showsCameraSwitchButton.
My implementation for this library in my project was to let the user using the front camera only. With this optional showsCameraSwitchButton flag we can initialise DKCamera with only that selected cam available.